### PR TITLE
Fixes issue #8

### DIFF
--- a/public/assets/js/module/Events.mjs
+++ b/public/assets/js/module/Events.mjs
@@ -3,7 +3,7 @@ import { Categories, Summary } from "./Modal.mjs";
 // Dispatch a message event to parent window
 export function message(type,payload = null) {
 	payload = JSON.stringify(payload);
-	window.parent.postMessage(`{"type":"${type}","payload":${payload}}`,window.top);
+	window.parent.postMessage(`{"type":"${type}","payload":${payload}}`,window.parent);
 }
 
 export class EventHandler {

--- a/public/assets/js/module/Events.mjs
+++ b/public/assets/js/module/Events.mjs
@@ -3,7 +3,7 @@ import { Categories, Summary } from "./Modal.mjs";
 // Dispatch a message event to parent window
 export function message(type,payload = null) {
 	payload = JSON.stringify(payload);
-	window.parent.postMessage(`{"type":"${type}","payload":${payload}}`,window.parent);
+	window.parent.postMessage(`{"type":"${type}","payload":${payload}}`);
 }
 
 export class EventHandler {

--- a/public/assets/js/module/Events.mjs
+++ b/public/assets/js/module/Events.mjs
@@ -3,7 +3,7 @@ import { Categories, Summary } from "./Modal.mjs";
 // Dispatch a message event to parent window
 export function message(type,payload = null) {
 	payload = JSON.stringify(payload);
-	window.parent.postMessage(`{"type":"${type}","payload":${payload}}`);
+	window.parent.postMessage(`{"type":"${type}","payload":${payload}}`,"*");
 }
 
 export class EventHandler {


### PR DESCRIPTION
Made the literal `"*"` the `windowOrigin` of `postMessage()`.

This resolves the issue with GitHub pages raising a CORS error when embedded on third-party sites